### PR TITLE
Traducción inicial del README.md al español

### DIFF
--- a/LEEME.md
+++ b/LEEME.md
@@ -1,0 +1,59 @@
+## Recursos compartidos vía la comunidad de Python Venezuela
+
+- [Awesome PythonVe](#awesome-python-ve)
+    - [API REST](#api-rest)
+    - [Recursos para Django](#recursos-para-django)
+    - [Recursos para el desarrollo de Backends](#Recursos-para-el-desarrollo-de-Backends)
+    - [Recursos relacionados con las Bases de Datos](#recurosos-relacionados-con-las-bases-de-datos)
+
+- - -
+
+## API REST
+
+*Bibliotecas para el desarrollo de APIs RESTful*
+* [django-rest-framework](http://www.django-rest-framework.org/) - Un conjunto
+poderoso y flexible de herramientas que facilita la construcción de *APIs* web.
+* [django-rest-framework-gis](https://github.com/djangonauts/django-rest-framework-gis) -
+Aditivos geográficos para el marco de trabajo *Django*.
+
+- - -
+
+## Recursos para Django
+
+*Recursos para Django.*
+* [django-model-utils](https://django-model-utils.readthedocs.org/en/latest/) -
+*Mixins* y utilidades para los modelos en *Django*.
+* [celery](http://celery.readthedocs.org/en/latest/django/first-steps-with-django.html) - Colas de tareas distribuídas (para que sean utilizadas dentro de *Django*).
+
+- - -
+
+## Recursos para el desarrollo de Backends
+
+*Recursos para desarrollar componentes y servidores de backend*
+* [celery](http://www.celeryproject.org/) - Cola de tareas distribuidas.
+
+- - -
+
+## Recurosos relacionados con las Bases de Datos
+
+### Conectores
+
+* [psycopg2](http://initd.org/psycopg/) - *Psycopg* es el adaptador de
+*PostgreSQL* más popular.
+* [pymongo](http://api.mongodb.org/python/current/) - Conector para *MongoDB*
+desde *Python*.
+
+### ORM tools
+
+* [SQLAlchemy][sqlalchemy] - Es un conjunto de herramientas para *SQL* y es un
+*Asociador entre Objetos y Tablas Relacionales* (*ORM*).
+* [Alembic](http://alembic.readthedocs.org/) - Herramienta ligera de migración
+de bases de datos para que sea utilizada con [SQLAlchemy][sqlalchemy].
+
+[sqlalchemy]: http://www.sqlalchemy.org/
+
+## License
+
+[![Creative Commons License](http://i.creativecommons.org/l/by/4.0/88x31.png)](http://creativecommons.org/licenses/by/4.0/)
+
+Este trabajo tiene licencia [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
Añadí `LEEME.md` como primera traducción.

Creo sin embargo, que los archivos deberían ser:
- `README.md` (en español)
- `README.es.md` (en español)
- `README.en.md` (en inglués)

Donde `README.md` sea una copiad del _README_ escrito en el lenguaje que queremos resaltar en la página inicial de _Github_.
